### PR TITLE
Prompt for manual circulating supply when CoinGecko misses

### DIFF
--- a/src/model/crypto_data.py
+++ b/src/model/crypto_data.py
@@ -69,7 +69,18 @@ def fetch_coin_info(ticker: str) -> Dict[str, float]:
         ) from exc
     data = data_resp.json()
     price = data["market_data"]["current_price"]["usd"]
-    supply = data["market_data"]["circulating_supply"]
+    supply = data["market_data"].get("circulating_supply")
+    if not supply:
+        print("Failed to fetch circulating supply from CoinGecko.")
+        while True:
+            user_input = input("Please enter the circulating supply manually: ")
+            try:
+                supply = float(user_input)
+                if supply > 0:
+                    break
+            except ValueError:
+                pass
+            print("Invalid input. Enter a positive number.")
     return {"price": price, "circulating_supply": supply}
 
 

--- a/tests/test_coin_info.py
+++ b/tests/test_coin_info.py
@@ -21,3 +21,24 @@ def test_fetch_coin_info_handles_http_error(monkeypatch):
     with pytest.raises(ValueError) as exc:
         crypto_data.fetch_coin_info("aeg")
     assert "Too Many Requests" in str(exc.value)
+
+
+def test_fetch_coin_info_prompts_for_supply(monkeypatch):
+    monkeypatch.setattr(crypto_data, "_get_coin_id", lambda ticker: "foo")
+
+    class Resp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "market_data": {
+                    "current_price": {"usd": 1.0},
+                    "circulating_supply": None,
+                }
+            }
+
+    monkeypatch.setattr(crypto_data.requests, "get", lambda url, timeout=30: Resp())
+    monkeypatch.setattr("builtins.input", lambda prompt="": "12345")
+    info = crypto_data.fetch_coin_info("foo")
+    assert info["circulating_supply"] == 12345.0


### PR DESCRIPTION
## Summary
- prompt the user for circulating supply if CoinGecko doesn't provide it
- test that manual input is used when supply is missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0522672b08326be5804a6ac2e9ed1