### PR TITLE
Add liquidation mode with selloff analysis

### DIFF
--- a/tests/test_liquidation.py
+++ b/tests/test_liquidation.py
@@ -1,0 +1,43 @@
+import csv
+import math
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from model.crypto_data import save_liquidation_model
+
+def test_save_liquidation_model(tmp_path):
+    price = 0.0225
+    supply = 58_345_815
+    ph_percentage = 0.275
+    out_file = tmp_path / "liquidation.csv"
+
+    save_liquidation_model(
+        str(out_file), price, supply, ph_percentage, final_price=0.01, q_pct=1.0
+    )
+
+    with open(out_file, newline="") as f:
+        rows = list(csv.reader(f))
+
+    assert rows[0][0] == "step"
+    data_rows = [r for r in rows[1:] if r]
+    assert data_rows
+
+    first = data_rows[0]
+    assert abs(float(first[2]) - price) < 1e-9
+    tokens_to_sell = supply * ph_percentage
+    steps = math.ceil((1 - 0.01 / price) / 0.05) + 1
+    q_factor = 1.0 + 1.0 / 100.0
+    if q_factor == 1.0:
+        expected_b1 = tokens_to_sell / steps
+    else:
+        expected_b1 = tokens_to_sell * (1 - q_factor) / (1 - q_factor ** steps)
+    assert abs(float(first[3]) - expected_b1) < 1e-6
+
+    last = data_rows[-1]
+    assert float(last[2]) <= 0.01
+    assert float(last[2]) >= 0.01 - price * 0.05
+    assert abs(float(last[4]) - tokens_to_sell) < 1e-6
+    assert abs(float(last[8]) - (supply + float(last[4]))) < 1e-6
+    assert float(last[9]) == float(last[4])

--- a/tests/test_selloffs.py
+++ b/tests/test_selloffs.py
@@ -1,0 +1,52 @@
+import csv
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from model.crypto_data import save_selloff_snippets
+
+def test_save_selloff_snippets(tmp_path):
+    day_ms = 24 * 60 * 60 * 1000
+    ohlcv = [
+        [0, 1.0, 1.1, 0.9, 1.0, 10.0],
+        [day_ms, 1.0, 1.1, 0.9, 1.0, 20.0],
+        [2 * day_ms, 1.0, 1.1, 0.4, 0.5, 100.0],
+        [3 * day_ms, 1.0, 1.1, 0.9, 1.0, 30.0],
+        [4 * day_ms, 1.0, 1.1, 0.9, 1.0, 40.0],
+    ]
+
+    out_file = tmp_path / "selloffs.csv"
+    supply = 1000.0
+    avg = save_selloff_snippets(str(out_file), ohlcv, supply, multiplier=0.5)
+
+    with open(out_file, newline="") as f:
+        rows = list(csv.reader(f))
+
+    header = rows[0]
+    data_rows = [r for r in rows[1:] if r]
+
+    assert len(data_rows) == 5
+    assert "ph_volume" in header
+    assert "ph_percentage" in header
+
+    sell_row = next(r for r in data_rows if r[7] == "1")
+    ph_volume_idx = header.index("ph_volume")
+    ph_percentage_idx = header.index("ph_percentage")
+    assert float(sell_row[ph_volume_idx]) == 75.0
+    assert float(sell_row[ph_percentage_idx]) == 0.075
+    assert avg == 0.075
+
+def test_average_multiple_events(tmp_path):
+    day_ms = 24 * 60 * 60 * 1000
+    ohlcv = [
+        [0, 1.0, 1.1, 0.4, 0.5, 100.0],
+        [day_ms, 1.0, 1.1, 0.9, 1.0, 20.0],
+        [2 * day_ms, 1.0, 1.1, 0.4, 0.5, 80.0],
+        [3 * day_ms, 1.0, 1.1, 0.9, 1.0, 30.0],
+        [4 * day_ms, 1.0, 1.1, 0.9, 1.0, 40.0],
+    ]
+    out_file = tmp_path / "selloffs2.csv"
+    avg = save_selloff_snippets(str(out_file), ohlcv, 1000.0, multiplier=0.5)
+    expected = ((100.0 - (20.0 + 80.0) / 2) / 1000.0 + (80.0 - (100.0 + 20.0 + 30.0 + 40.0) / 4) / 1000.0) / 2
+    assert avg == expected


### PR DESCRIPTION
## Summary
- add selloff snippet extraction and liquidation model generation
- extend CLI with buyback vs liquidation modes
- cover new features with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2f26682408326ac5705f7c89953ac