### PR TITLE
Add liquidation mode with selloff analysis

### DIFF
--- a/src/model/cli.py
+++ b/src/model/cli.py
@@ -10,7 +10,9 @@ from .crypto_data import (
     fetch_ohlcv,
     plot_buyback_chart,
     save_buyback_model,
+    save_selloff_snippets,
     save_surge_snippets,
+    save_liquidation_model,
     save_to_csv,
 )
 
@@ -26,40 +28,124 @@ def main() -> None:
 
     try:
         info = fetch_coin_info(args.ticker)
-        ohlcv = fetch_ohlcv(args.ticker)
+        ohlcv_map = fetch_ohlcv(args.ticker)
     except ValueError as exc:
         print(exc)
         return
 
-    filename = args.output or f"{args.ticker.upper()}_data.csv"
-    save_to_csv(filename, info, ohlcv)
-    print(f"Data written to {filename}")
-
-    surge_filename = filename.replace("_data", "_surges")
-    avg = save_surge_snippets(surge_filename, ohlcv, info["circulating_supply"])
-    print(f"Surge snippets written to {surge_filename}")
-    print(f"Average PH percentage: {avg}")
-
-    try:
-        final_price = float(input("Final desired price for buyback: "))
-        q_pct = float(input("Increase in sell rate q percentage: "))
-    except ValueError:
-        print("Invalid numeric input")
+    if not ohlcv_map:
+        print("No OHLCV data available")
         return
 
-    buyback_filename = filename.replace("_data", "_buyback")
-    save_buyback_model(
-        buyback_filename,
-        info["price"],
-        info["circulating_supply"],
-        avg,
-        final_price,
-        q_pct,
-    )
-    print(f"Buyback model written to {buyback_filename}")
-    chart_file = buyback_filename.replace(".csv", ".png")
-    plot_buyback_chart(buyback_filename, chart_file)
-    print(f"Buyback chart written to {chart_file}")
+    base = args.output or args.ticker.upper()
+    if base.lower().endswith('.csv'):
+        base = base[:-4]
+    for ex, data in ohlcv_map.items():
+        filename = f"{base}_{ex}_data.csv"
+        save_to_csv(filename, info, data)
+        print(f"Data written to {filename}")
+
+    mode = input("Select mode: buyback or liquidation (b/l): ").strip().lower()
+    if mode.startswith("b"):
+        try:
+            pct_input = input(
+                "Minimum intraday surge percentage (default 75): "
+            ).strip()
+            surge_pct = float(pct_input) if pct_input else 75.0
+        except ValueError:
+            print("Invalid numeric input")
+            return
+        surge_pct = abs(surge_pct)
+        avgs = []
+        for ex, data in ohlcv_map.items():
+            surge_filename = f"{base}_{ex}_surges.csv"
+            avg = save_surge_snippets(
+                surge_filename,
+                data,
+                info["circulating_supply"],
+                1 + surge_pct / 100,
+            )
+            print(f"Surge snippets written to {surge_filename}")
+            print(f"Average PH percentage on {ex}: {avg}")
+            avgs.append(avg)
+        avg = sum(avgs) / len(avgs) if avgs else 0.0
+        print(f"Average PH percentage: {avg}")
+
+        try:
+            final_price = float(input("Final desired price for buyback: "))
+            q_pct = float(input("Increase in sell rate q percentage: "))
+            step_input = input(
+                "Price step percentage for schedule (default 5): "
+            ).strip()
+            step_pct = float(step_input) if step_input else 5.0
+        except ValueError:
+            print("Invalid numeric input")
+            return
+        buyback_filename = f"{base}_buyback.csv"
+        save_buyback_model(
+            buyback_filename,
+            info["price"],
+            info["circulating_supply"],
+            avg,
+            final_price,
+            q_pct,
+            step_pct,
+        )
+        print(f"Buyback model written to {buyback_filename}")
+        chart_file = buyback_filename.replace(".csv", ".png")
+        plot_buyback_chart(buyback_filename, chart_file)
+        print(f"Buyback chart written to {chart_file}")
+    elif mode.startswith("l"):
+        try:
+            pct_input = input(
+                "Maximum intraday selloff percentage (default -50): "
+            ).strip()
+            selloff_pct = float(pct_input) if pct_input else -50.0
+        except ValueError:
+            print("Invalid numeric input")
+            return
+        selloff_pct = -abs(selloff_pct)
+        avgs = []
+        for ex, data in ohlcv_map.items():
+            selloff_filename = f"{base}_{ex}_selloffs.csv"
+            avg = save_selloff_snippets(
+                selloff_filename,
+                data,
+                info["circulating_supply"],
+                1 + selloff_pct / 100,
+            )
+            print(f"Selloff snippets written to {selloff_filename}")
+            print(f"Average PH percentage on {ex}: {avg}")
+            avgs.append(avg)
+        avg = sum(avgs) / len(avgs) if avgs else 0.0
+        print(f"Average PH percentage: {avg}")
+
+        try:
+            final_price = float(input("Final desired price for liquidation: "))
+            q_pct = float(
+                input("Increase in sell buy rate q percentage: ")
+            )
+            step_input = input(
+                "Price step percentage for schedule (default 5): "
+            ).strip()
+            step_pct = float(step_input) if step_input else 5.0
+        except ValueError:
+            print("Invalid numeric input")
+            return
+        liquidation_filename = f"{base}_liquidation.csv"
+        save_liquidation_model(
+            liquidation_filename,
+            info["price"],
+            info["circulating_supply"],
+            avg,
+            final_price,
+            q_pct,
+            step_pct,
+        )
+        print(f"Liquidation model written to {liquidation_filename}")
+    else:
+        print("Invalid mode selected")
+        return
 
 
 if __name__ == "__main__":

--- a/src/model/crypto_data.py
+++ b/src/model/crypto_data.py
@@ -19,6 +19,38 @@ MS_IN_DAY = 24 * 60 * 60 * 1000
 DAYS_LIMIT = 364
 
 
+# CoinGecko only accepts a limited set of "days" parameters for its OHLC
+# endpoint.  Use the smallest allowed value greater than or equal to the
+# desired ``DAYS_LIMIT``.  This prevents HTTP 400 errors such as the
+# ``{"error":"Invalid days parameter"}`` seen when requesting 364 days.
+COINGECKO_ALLOWED_DAYS = [1, 7, 14, 30, 90, 180, 365, 730]
+
+
+def _coingecko_days(limit: int) -> int:
+    """Return a valid ``days`` value for CoinGecko's OHLC endpoint."""
+
+    for day in COINGECKO_ALLOWED_DAYS:
+        if limit <= day:
+            return day
+    return COINGECKO_ALLOWED_DAYS[-1]
+
+
+# Map CoinGecko market identifiers to ccxt exchange ids.  CoinGecko still
+# uses legacy identifiers like ``mxc`` for MEXC; normalising ensures those
+# exchanges appear in the available list.
+EXCHANGE_ALIASES = {
+    "mxc": "mexc",
+    "gate-io": "gate",
+    "gateio": "gate",
+}
+
+
+def _normalize_exchange_id(exchange_id: str) -> str:
+    """Normalise CoinGecko market identifiers for ccxt."""
+
+    return EXCHANGE_ALIASES.get(exchange_id.lower(), exchange_id.lower())
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -105,56 +137,49 @@ def _coin_markets(ticker: str) -> List[Tuple[str, str]]:
     return markets
 
 
-def fetch_ohlcv(ticker: str, exchange: str | None = None) -> List[List[float]]:
+def fetch_ohlcv(ticker: str, exchange: str | None = None) -> Dict[str, List[List[float]]]:
     """Fetch up to the last ``DAYS_LIMIT`` days of OHLCV data.
 
-    Data is retrieved from ccxt exchanges when available; otherwise the
-    CoinGecko OHLC endpoint is used as a fallback.
+    When ``exchange`` is ``None`` data is fetched from *all* ccxt-supported
+    exchanges reported by CoinGecko. Results are returned in a dictionary
+    mapping exchange id to OHLCV rows. If no exchange yields data, the
+    function falls back to CoinGecko's OHLC endpoint with the key
+    ``"coingecko"``.
     """
 
     markets = _coin_markets(ticker)
     logger.debug("Found %d markets for %s", len(markets), ticker)
 
-    supported_markets = [m for m in markets if m[0] in ccxt.exchanges]
-    exchanges = sorted({ex for ex, _ in supported_markets})
+    normalized_markets = [(_normalize_exchange_id(ex), pair) for ex, pair in markets]
+    supported_markets = [m for m in normalized_markets if m[0] in ccxt.exchanges]
+    markets_by_exchange: Dict[str, List[str]] = {}
+    for ex, pair in supported_markets:
+        markets_by_exchange.setdefault(ex, []).append(pair)
 
-    if exchange is None and exchanges:
-        if len(exchanges) > 1:
-            print(f"Available exchanges for {ticker}:")
-            for idx, ex in enumerate(exchanges, start=1):
-                print(f"{idx}. {ex}")
-            while True:
-                choice = input(f"Select exchange [1-{len(exchanges)}]: ")
-                try:
-                    idx = int(choice)
-                    if 1 <= idx <= len(exchanges):
-                        exchange = exchanges[idx - 1]
-                        break
-                except ValueError:
-                    pass
-                print("Invalid selection. Please try again.")
-        else:
-            exchange = exchanges[0]
+    # Notify about markets that cannot be fetched via ccxt.
+    unsupported = sorted(
+        {ex for ex, _ in markets if _normalize_exchange_id(ex) not in ccxt.exchanges}
+    )
+    if unsupported:
+        logger.info("Unsupported exchanges: %s", ", ".join(unsupported))
 
-    if exchange and exchange not in ccxt.exchanges:
-        raise ValueError(f"Exchange {exchange} not supported by ccxt")
+    exchanges_to_try = [exchange] if exchange else sorted(markets_by_exchange)
+    if not exchanges_to_try:
+        exchanges_to_try = list(ccxt.exchanges)
 
-    attempted: set[str] = set()
-    markets_to_try = [m for m in supported_markets if not exchange or m[0] == exchange]
+    results: Dict[str, List[List[float]]] = {}
 
     now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
     since_start = now_ms - DAYS_LIMIT * MS_IN_DAY
 
-    for exchange_name, symbol in markets_to_try:
-        attempted.add(exchange_name)
-        exchange_class = getattr(ccxt, exchange_name)({"enableRateLimit": True})
+    def _fetch_from_exchange(ex_name: str, symbol: str) -> List[List[float]]:
+        exchange_class = getattr(ccxt, ex_name)({"enableRateLimit": True})
         timeframe = "1d"
         since = since_start
         all_data: List[List[float]] = []
-        logger.debug("Trying %s %s", exchange_name, symbol)
+        logger.debug("Trying %s %s", ex_name, symbol)
         try:
             exchange_class.load_markets()
-
             while True:
                 batch = exchange_class.fetch_ohlcv(
                     symbol, timeframe=timeframe, since=since, limit=DAYS_LIMIT
@@ -167,15 +192,35 @@ def fetch_ohlcv(ticker: str, exchange: str | None = None) -> List[List[float]]:
                     break
                 since = batch[-1][0] + MS_IN_DAY
             if all_data:
-                logger.info(
-                    "Fetched %d rows from %s %s", len(all_data), exchange_name, symbol
-                )
+                logger.info("Fetched %d rows from %s %s", len(all_data), ex_name, symbol)
                 return all_data[-DAYS_LIMIT:]
         except Exception as exc:
-            logger.warning("Failed to fetch %s on %s: %s", symbol, exchange_name, exc)
-            continue
+            logger.warning("Failed to fetch %s on %s: %s", symbol, ex_name, exc)
+            try:
+                batch = exchange_class.fetch_ohlcv(
+                    symbol, timeframe=timeframe, limit=DAYS_LIMIT
+                )
+                if batch:
+                    logger.info("Fetched %d rows from %s %s", len(batch), ex_name, symbol)
+                    return batch[-DAYS_LIMIT:]
+            except Exception as exc2:
+                logger.warning(
+                    "Retry without since failed for %s on %s: %s",
+                    symbol,
+                    ex_name,
+                    exc2,
+                )
+        return []
 
-    # Try common trading pairs on selected or all exchanges before using CoinGecko
+    # First try explicit markets reported by CoinGecko
+    for ex_name in exchanges_to_try:
+        for symbol in markets_by_exchange.get(ex_name, []):
+            data = _fetch_from_exchange(ex_name, symbol)
+            if data:
+                results[ex_name] = data
+                break
+
+    # Try common trading pairs on exchanges that still lack data
     base_symbol = ticker.upper()
     generic_pairs = [
         f"{base_symbol}/USDT",
@@ -183,43 +228,25 @@ def fetch_ohlcv(ticker: str, exchange: str | None = None) -> List[List[float]]:
         f"{base_symbol}/BTC",
     ]
 
-    exchange_list = [exchange] if exchange else ccxt.exchanges
-    for exchange_name in exchange_list:
-        if exchange_name in attempted:
+    for ex_name in exchanges_to_try:
+        if ex_name in results:
             continue
-        exchange_class = getattr(ccxt, exchange_name)({"enableRateLimit": True})
+        exchange_class = getattr(ccxt, ex_name)({"enableRateLimit": True})
         try:
             exchange_class.load_markets()
         except Exception as exc:
-            logger.debug("Skipping %s: %s", exchange_name, exc)
+            logger.debug("Skipping %s: %s", ex_name, exc)
             continue
         for symbol in generic_pairs:
             if symbol not in getattr(exchange_class, "symbols", []):
                 continue
-            timeframe = "1d"
-            since = since_start
-            all_data: List[List[float]] = []
-            logger.debug("Trying %s %s", exchange_name, symbol)
-            try:
-                while True:
-                    batch = exchange_class.fetch_ohlcv(
-                        symbol, timeframe=timeframe, since=since, limit=DAYS_LIMIT
-                    )
-                    if not batch:
-                        break
-                    all_data.extend(batch)
-                    if len(all_data) >= DAYS_LIMIT:
-                        all_data = all_data[-DAYS_LIMIT:]
-                        break
-                    since = batch[-1][0] + MS_IN_DAY
-                if all_data:
-                    logger.info(
-                        "Fetched %d rows from %s %s", len(all_data), exchange_name, symbol
-                    )
-                    return all_data[-DAYS_LIMIT:]
-            except Exception as exc:
-                logger.warning("Failed to fetch %s on %s: %s", symbol, exchange_name, exc)
+            data = _fetch_from_exchange(ex_name, symbol)
+            if data:
+                results[ex_name] = data
                 break
+
+    if results:
+        return results
 
     # Fall back to CoinGecko's OHLC endpoint if all ccxt markets fail
     logger.info("Falling back to CoinGecko OHLC for %s", ticker)
@@ -227,7 +254,7 @@ def fetch_ohlcv(ticker: str, exchange: str | None = None) -> List[List[float]]:
     try:
         resp = requests.get(
             f"{COINGECKO_API}/coins/{coin_id}/ohlc",
-            params={"vs_currency": "usd", "days": DAYS_LIMIT},
+            params={"vs_currency": "usd", "days": _coingecko_days(DAYS_LIMIT)},
             timeout=30,
         )
         resp.raise_for_status()
@@ -243,7 +270,7 @@ def fetch_ohlcv(ticker: str, exchange: str | None = None) -> List[List[float]]:
     data = data[-DAYS_LIMIT:]
 
     # CoinGecko's OHLC endpoint does not provide volume; set it to 0.0
-    return [row + [0.0] for row in data]
+    return {"coingecko": [row + [0.0] for row in data]}
 
 
 def save_to_csv(filename: str, info: Dict[str, float], ohlcv: List[List[float]]) -> None:
@@ -339,6 +366,83 @@ def save_surge_snippets(
     return sum(averages) / len(averages) if averages else 0.0
 
 
+def save_selloff_snippets(
+    filename: str,
+    ohlcv: List[List[float]],
+    supply: float,
+    multiplier: float = 0.5,
+) -> float:
+    """Save windows around days where intraday low falls below ``multiplier``× open.
+
+    ``multiplier`` defaults to ``0.5`` (50% dump).
+
+    ``supply`` is the circulating supply of the token and is used to compute
+    ``ph_percentage`` (``ph_volume`` divided by supply).
+
+    For each day where ``low / open`` is at most ``multiplier``, write a five-day
+    window (two days before and after the selloff) to ``filename``. The CSV
+    mirrors :func:`save_surge_snippets` and includes ``event_id`` to group rows,
+    ``is_event_day`` flag, and ``ph_volume``/``ph_percentage`` columns.
+    """
+
+    averages: List[float] = []
+    with open(filename, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            [
+                "event_id",
+                "date",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "is_event_day",
+                "ph_volume",
+                "ph_percentage",
+            ]
+        )
+        event_id = 1
+        for i, (ts, open_, high, low, close, volume) in enumerate(ohlcv):
+            if open_ > 0 and (low / open_) <= multiplier:
+                start = max(0, i - 2)
+                end = min(len(ohlcv), i + 3)
+
+                surrounding: List[float] = []
+                for offset in (-2, -1, 1, 2):
+                    j = i + offset
+                    if 0 <= j < len(ohlcv):
+                        surrounding.append(ohlcv[j][5])
+                avg_surrounding = (
+                    sum(surrounding) / len(surrounding) if surrounding else 0.0
+                )
+                ph_volume = volume - avg_surrounding
+                ph_percentage = ph_volume / supply if supply else 0.0
+                averages.append(ph_percentage)
+                for j in range(start, end):
+                    ts2, o2, h2, l2, c2, v2 = ohlcv[j]
+                    writer.writerow(
+                        [
+                            event_id,
+                            datetime.utcfromtimestamp(ts2 / 1000).strftime(
+                                "%d-%m-%Y"
+                            ),
+                            o2,
+                            h2,
+                            l2,
+                            c2,
+                            v2,
+                            1 if j == i else 0,
+                            ph_volume,
+                            ph_percentage,
+                        ]
+                    )
+                writer.writerow([])
+                event_id += 1
+
+    return sum(averages) / len(averages) if averages else 0.0
+
+
 def save_buyback_model(
     filename: str,
     price: float,
@@ -346,19 +450,20 @@ def save_buyback_model(
     ph_percentage: float,
     final_price: float,
     q_pct: float,
+    step_pct: float = 5.0,
 ) -> None:
     """Create a buyback model CSV based on selling pressure parameters.
 
     ``price`` and ``supply`` come from CoinGecko. ``ph_percentage`` is the
     average paper-hands percentage computed from surge snippets. ``final_price``
     specifies the last price level to model. Each row increases the price by a
-    fixed 5% step. ``q_pct`` is the percentage increase in sell volume per step
-    (e.g. 1 for a 1% increase).
+    configurable ``step_pct`` percentage (default 5%). ``q_pct`` is the
+    percentage increase in sell volume per step (e.g. 1 for a 1% increase).
 
-    The resulting CSV contains a row for each 5%% price step until the price meets
-    or exceeds ``final_price``. The model no longer halts when the estimated
-    paper-hands token pool runs out; sales continue geometrically regardless of
-    totals.
+    The resulting CSV contains a row for each ``step_pct`` price step until the
+    price meets or exceeds ``final_price``. The model no longer halts when the
+    estimated paper-hands token pool runs out; sales continue geometrically
+    regardless of totals.
     """
 
     tokens_to_sell = supply * ph_percentage
@@ -382,9 +487,9 @@ def save_buyback_model(
         if tokens_to_sell <= 0:
             return
 
-        step_inc = 0.05
+        step_inc = step_pct / 100.0
         q_factor = 1.0 + q_pct / 100.0
-        # number of 5% steps required to reach the target price
+        # number of steps required to reach the target price
         steps = math.ceil((final_price / price - 1) / step_inc) + 1
         if q_factor == 1.0:
             tokens_step = tokens_to_sell / steps
@@ -420,6 +525,87 @@ def save_buyback_model(
                 break
             tokens_step *= q_factor
             price_mult += step_inc
+            step += 1
+
+
+def save_liquidation_model(
+    filename: str,
+    price: float,
+    supply: float,
+    ph_percentage: float,
+    final_price: float,
+    q_pct: float,
+    step_pct: float = 5.0,
+) -> None:
+    """Create a liquidation model CSV based on dumping pressure parameters.
+
+    ``price`` and ``supply`` come from CoinGecko. ``ph_percentage`` is the
+    average paper-hands percentage computed from selloff snippets. ``final_price``
+    specifies the last price level to model (typically below the current price).
+    Each row decreases the price by a configurable ``step_pct`` percentage
+    (default 5%). ``q_pct`` is the percentage increase in sell volume per step
+    (e.g. 1 for a 1% increase).
+    """
+
+    tokens_to_sell = supply * ph_percentage
+    with open(filename, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            [
+                "step",
+                "x",
+                "price_usd",
+                "tokens_sold",
+                "tokens_sold_cumulative",
+                "usd_value",
+                "usd_value_cumulative",
+                "weighted_avg_price",
+                "freefloat",
+                "sell_out_tokens",
+            ]
+        )
+
+        if tokens_to_sell <= 0:
+            return
+
+        step_inc = step_pct / 100.0
+        q_factor = 1.0 + q_pct / 100.0
+        steps = max(1, math.ceil((1 - final_price / price) / step_inc) + 1)
+        if q_factor == 1.0:
+            tokens_step = tokens_to_sell / steps
+        else:
+            tokens_step = tokens_to_sell * (1 - q_factor) / (1 - q_factor ** steps)
+
+        step = 1
+        price_mult = 1.0
+        sold_cum = 0.0
+        usd_cum = 0.0
+        while True:
+            price_level = price * price_mult
+            sell_now = tokens_step
+            sold_cum += sell_now
+            usd_now = sell_now * price_level
+            usd_cum += usd_now
+            weighted_avg = usd_cum / sold_cum if sold_cum else 0.0
+            freefloat = supply + sold_cum
+            writer.writerow(
+                [
+                    step,
+                    round(price_mult, 2),
+                    price_level,
+                    sell_now,
+                    sold_cum,
+                    usd_now,
+                    usd_cum,
+                    weighted_avg,
+                    freefloat,
+                    sold_cum,
+                ]
+            )
+            if price_level <= final_price:
+                break
+            tokens_step *= q_factor
+            price_mult -= step_inc
             step += 1
 
 

--- a/tests/test_exchange_utils.py
+++ b/tests/test_exchange_utils.py
@@ -1,0 +1,11 @@
+from model.crypto_data import _coingecko_days, _normalize_exchange_id
+
+
+def test_coingecko_days_rounding():
+    assert _coingecko_days(364) == 365
+    assert _coingecko_days(90) == 90
+
+
+def test_exchange_normalization():
+    assert _normalize_exchange_id('mxc') == 'mexc'
+    assert _normalize_exchange_id('gate') == 'gate'

--- a/tests/test_fetch_fallback.py
+++ b/tests/test_fetch_fallback.py
@@ -31,4 +31,5 @@ def test_fetch_ohlcv_generic_exchange(monkeypatch):
     monkeypatch.setattr(crypto_data, "ccxt", fake_ccxt)
 
     data = crypto_data.fetch_ohlcv("fury")
-    assert data[0][1:] == [1, 2, 3, 4, 5]
+    assert set(data.keys()) == {"fake"}
+    assert data["fake"][0][1:] == [1, 2, 3, 4, 5]

--- a/tests/test_fetch_multi.py
+++ b/tests/test_fetch_multi.py
@@ -7,23 +7,11 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 from model import crypto_data
 
 
-def test_fetch_ohlcv_specific_exchange(monkeypatch):
+def test_fetch_ohlcv_all_exchanges(monkeypatch):
     markets = [("ex1", "AAA/USDT"), ("ex2", "AAA/USDT")]
     monkeypatch.setattr(crypto_data, "_coin_markets", lambda ticker: markets)
 
     class Ex1:
-        symbols = ["AAA/USDT"]
-
-        def __init__(self, params=None):
-            pass
-
-        def load_markets(self):
-            return
-
-        def fetch_ohlcv(self, symbol, timeframe="1d", since=0, limit=1000):
-            raise AssertionError("Ex1 should not be queried")
-
-    class Ex2:
         symbols = ["AAA/USDT"]
 
         def __init__(self, params=None):
@@ -39,11 +27,27 @@ def test_fetch_ohlcv_specific_exchange(monkeypatch):
             self.called = True
             return [[since, 1, 2, 3, 4, 5]]
 
+    class Ex2:
+        symbols = ["AAA/USDT"]
+
+        def __init__(self, params=None):
+            self.called = False
+
+        def load_markets(self):
+            return
+
+        def fetch_ohlcv(self, symbol, timeframe="1d", since=0, limit=1000):
+            assert since > 0
+            if self.called:
+                return []
+            self.called = True
+            return [[since, 6, 7, 8, 9, 10]]
+
     fake_ccxt = types.SimpleNamespace(exchanges=["ex1", "ex2"], ex1=Ex1, ex2=Ex2)
     monkeypatch.setattr(crypto_data, "ccxt", fake_ccxt)
 
-    # Simulate user selecting the second exchange from the prompt
-    monkeypatch.setattr("builtins.input", lambda _: "2")
-
     data = crypto_data.fetch_ohlcv("aaa")
-    assert data[0][1:] == [1, 2, 3, 4, 5]
+    assert set(data.keys()) == {"ex1", "ex2"}
+    assert data["ex1"][0][1:] == [1, 2, 3, 4, 5]
+    assert data["ex2"][0][1:] == [6, 7, 8, 9, 10]
+

--- a/tests/test_selloffs.py
+++ b/tests/test_selloffs.py
@@ -1,0 +1,52 @@
+import csv
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from model.crypto_data import save_selloff_snippets
+
+def test_save_selloff_snippets(tmp_path):
+    day_ms = 24 * 60 * 60 * 1000
+    ohlcv = [
+        [0, 1.0, 1.1, 0.9, 1.0, 10.0],
+        [day_ms, 1.0, 1.1, 0.9, 1.0, 20.0],
+        [2 * day_ms, 1.0, 1.1, 0.4, 0.5, 100.0],
+        [3 * day_ms, 1.0, 1.1, 0.9, 1.0, 30.0],
+        [4 * day_ms, 1.0, 1.1, 0.9, 1.0, 40.0],
+    ]
+
+    out_file = tmp_path / "selloffs.csv"
+    supply = 1000.0
+    avg = save_selloff_snippets(str(out_file), ohlcv, supply, multiplier=0.5)
+
+    with open(out_file, newline="") as f:
+        rows = list(csv.reader(f))
+
+    header = rows[0]
+    data_rows = [r for r in rows[1:] if r]
+
+    assert len(data_rows) == 5
+    assert "ph_volume" in header
+    assert "ph_percentage" in header
+
+    sell_row = next(r for r in data_rows if r[7] == "1")
+    ph_volume_idx = header.index("ph_volume")
+    ph_percentage_idx = header.index("ph_percentage")
+    assert float(sell_row[ph_volume_idx]) == 75.0
+    assert float(sell_row[ph_percentage_idx]) == 0.075
+    assert avg == 0.075
+
+def test_average_multiple_events(tmp_path):
+    day_ms = 24 * 60 * 60 * 1000
+    ohlcv = [
+        [0, 1.0, 1.1, 0.4, 0.5, 100.0],
+        [day_ms, 1.0, 1.1, 0.9, 1.0, 20.0],
+        [2 * day_ms, 1.0, 1.1, 0.4, 0.5, 80.0],
+        [3 * day_ms, 1.0, 1.1, 0.9, 1.0, 30.0],
+        [4 * day_ms, 1.0, 1.1, 0.9, 1.0, 40.0],
+    ]
+    out_file = tmp_path / "selloffs2.csv"
+    avg = save_selloff_snippets(str(out_file), ohlcv, 1000.0, multiplier=0.5)
+    expected = ((100.0 - (20.0 + 80.0) / 2) / 1000.0 + (80.0 - (100.0 + 20.0 + 30.0 + 40.0) / 4) / 1000.0) / 2
+    assert avg == expected


### PR DESCRIPTION
## Summary
- fetch OHLCV data from every ccxt-supported exchange and fall back to CoinGecko only if all fail
- update CLI to save per-exchange data and average paper-hands percentages across exchanges for buyback or liquidation plans
- cover multi-exchange fetching with dedicated tests and adjust fallback expectations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2f26682408326ac5705f7c89953ac