### PR TITLE
Improve CLI usability and standalone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,15 @@ paper-hands token buybacks.
 ## Usage
 
 ```bash
-python -m model.cli <ticker>
+crypto-fetch [ticker]
 ```
+
+If `ticker` is omitted, you will be prompted to enter it interactively.
 
 Example:
 
 ```bash
-python -m model.cli btc
+crypto-fetch btc
 ```
 
 Running the command performs the following steps:
@@ -73,6 +75,18 @@ Running the command performs the following steps:
    `<TICKER>_buyback.png`.
 
 Use the `--debug` flag to print detailed logging while the tool runs.
+
+### Build a standalone binary
+
+To distribute the CLI as a single executable (so end users do not need Python installed),
+bundle it with [PyInstaller](https://pyinstaller.org/):
+
+```bash
+pip install pyinstaller
+pyinstaller --name crypto-fetch --onefile src/model/cli.py --paths src
+```
+
+The compiled binary will be available in the `dist/` directory.
 
 ## Buyback model
 

--- a/src/model/cli.py
+++ b/src/model/cli.py
@@ -5,7 +5,7 @@ import argparse
 import logging
 
 
-from .crypto_data import (
+from model.crypto_data import (
     fetch_coin_info,
     fetch_ohlcv,
     plot_buyback_chart,
@@ -19,16 +19,18 @@ from .crypto_data import (
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Fetch token info and OHLCV data")
-    parser.add_argument("ticker", help="Token ticker symbol, e.g. btc")
+    parser.add_argument("ticker", nargs="?", help="Token ticker symbol, e.g. btc")
     parser.add_argument("--output", default=None, help="Output CSV filename")
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
 
+    ticker = args.ticker or input("Enter token ticker: ").strip()
+
     try:
-        info = fetch_coin_info(args.ticker)
-        ohlcv_map = fetch_ohlcv(args.ticker)
+        info = fetch_coin_info(ticker)
+        ohlcv_map = fetch_ohlcv(ticker)
     except ValueError as exc:
         print(exc)
         return
@@ -37,7 +39,7 @@ def main() -> None:
         print("No OHLCV data available")
         return
 
-    base = args.output or args.ticker.upper()
+    base = args.output or ticker.upper()
     if base.lower().endswith('.csv'):
         base = base[:-4]
     for ex, data in ohlcv_map.items():


### PR DESCRIPTION
## Summary
- Prompt for ticker when not provided
- Use absolute imports in CLI to support PyInstaller bundles
- Document `crypto-fetch` command and building a standalone binary

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba071941208326a3600a3002ba0511