### PR TITLE
Improve CLI usability and add OKX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ paper-hands token buybacks.
 - Fetch current USD price and circulating supply from CoinGecko.
 - Retrieve up to the last 364 days of daily OHLCV candles from an exchange via
   [ccxt](https://github.com/ccxt/ccxt) with automatic fallbacks to CoinGecko.
+- Normalise exchange identifiers from CoinGecko to ccxt (for example, `okex`
+  is mapped to `okx`) so OKX markets are supported out of the box.
 - Detect days where the intraday high is at least 75% above the open price and
   export five-day "surge snippets" that include `ph_volume` and `ph_percentage`
   metrics.
@@ -46,14 +48,28 @@ paper-hands token buybacks.
 ## Usage
 
 ```bash
-python -m model.cli <ticker>
+crypto-fetch [ticker]
 ```
+
+If `ticker` is omitted, you will be prompted to enter it interactively.
+
+When launched, the tool displays a brief introduction:
+
+```
+Paper Hands Model [Version 1.0]
+© Bitmaker L.L.C-FZ. All rights reserved.
+```
+
+If `colorama` is available, prompts are highlighted to provide a friendlier
+interface, but the CLI also runs without it for standalone builds.
 
 Example:
 
 ```bash
-python -m model.cli btc
+crypto-fetch btc
 ```
+
+All generated CSV and PNG files are stored in `dist/datasets/`.
 
 Running the command performs the following steps:
 
@@ -63,16 +79,49 @@ Running the command performs the following steps:
    are available.
 3. Download up to 364 days of OHLCV data from the chosen exchange or, if
    exchanges fail, from CoinGecko.
-4. Write `<TICKER>_data.csv` containing the current price, circulating supply
-   and OHLCV history.
-5. Generate `<TICKER>_surges.csv` with five-day windows around every surge where
+4. Write `dist/datasets/<TICKER>_data.csv` containing the current price,
+   circulating supply and OHLCV history.
+5. Generate `dist/datasets/<TICKER>_surges.csv` with five-day windows around
    `high / open >= 1.75`, including `ph_volume` and `ph_percentage` columns, and
    print the average paper-hands percentage.
 6. Prompt for a final buyback price and a percentage `q` increase in sell rate,
-   then create `<TICKER>_buyback.csv` together with a chart
-   `<TICKER>_buyback.png`.
+   then create `dist/datasets/<TICKER>_buyback.csv` together with a chart
+   `dist/datasets/<TICKER>_buyback.png`.
 
 Use the `--debug` flag to print detailed logging while the tool runs.
+
+### Build a standalone binary
+
+To distribute the CLI as a single executable (so end users do not need Python installed),
+bundle it with [PyInstaller](https://pyinstaller.org/):
+
+```bash
+pip install pyinstaller
+pyinstaller --name crypto-fetch --onefile src/model/cli.py --paths src
+```
+
+The compiled binary will be available in the `dist/` directory.
+
+### Run from Finder on macOS
+
+If you want to launch the binary by double-clicking in Finder, create a small
+wrapper script in the project root:
+
+```bash
+#!/bin/bash
+cd "$(dirname "$0")/dist"
+./crypto-fetch "$@"
+read -p "Press Enter to close..."
+```
+
+Save this as `crypto-fetch.command` and make it executable:
+
+```bash
+chmod +x crypto-fetch.command
+```
+
+Double-clicking `crypto-fetch.command` opens Terminal, runs the compiled
+binary, and keeps the window open until you press Enter.
 
 ## Buyback model
 

--- a/crypto-fetch.command
+++ b/crypto-fetch.command
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd "$(dirname "$0")/dist"
+./crypto-fetch "$@"
+read -p "Press Enter to close..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "ccxt",
     "requests",
     "matplotlib",
+    "colorama",
 ]
 
 [project.scripts]

--- a/src/model/cli.py
+++ b/src/model/cli.py
@@ -3,9 +3,22 @@ from __future__ import annotations
 
 import argparse
 import logging
+import sys
+from pathlib import Path
 
+try:
+    from colorama import Fore, Style, init
+except ModuleNotFoundError:  # pragma: no cover - fallback when colorama isn't bundled
+    class _NoColor:
+        def __getattr__(self, name: str) -> str:
+            return ""
 
-from .crypto_data import (
+    Fore = Style = _NoColor()
+
+    def init(*_args, **_kwargs):  # type: ignore
+        pass
+
+from model.crypto_data import (
     fetch_coin_info,
     fetch_ohlcv,
     plot_buyback_chart,
@@ -18,17 +31,30 @@ from .crypto_data import (
 
 
 def main() -> None:
+    init(autoreset=True)
+
+    def prompt(text: str) -> str:
+        return input(Fore.YELLOW + text + Style.RESET_ALL)
+
     parser = argparse.ArgumentParser(description="Fetch token info and OHLCV data")
-    parser.add_argument("ticker", help="Token ticker symbol, e.g. btc")
+    parser.add_argument("ticker", nargs="?", help="Token ticker symbol, e.g. btc")
     parser.add_argument("--output", default=None, help="Output CSV filename")
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
 
+    print(
+        Fore.CYAN
+        + "Paper Hands Model [Version 1.0]\n"
+        + "\u00A9 Bitmaker L.L.C-FZ. All rights reserved.\n"
+    )
+
+    ticker = args.ticker or prompt("Enter token ticker: ").strip()
+
     try:
-        info = fetch_coin_info(args.ticker)
-        ohlcv_map = fetch_ohlcv(args.ticker)
+        info = fetch_coin_info(ticker)
+        ohlcv_map = fetch_ohlcv(ticker)
     except ValueError as exc:
         print(exc)
         return
@@ -37,18 +63,25 @@ def main() -> None:
         print("No OHLCV data available")
         return
 
-    base = args.output or args.ticker.upper()
-    if base.lower().endswith('.csv'):
+    if getattr(sys, "frozen", False):
+        dist_dir = Path(sys.executable).resolve().parent
+    else:
+        dist_dir = Path(__file__).resolve().parent.parent.parent / "dist"
+    datasets_dir = dist_dir / "datasets"
+    datasets_dir.mkdir(parents=True, exist_ok=True)
+
+    base = args.output or ticker.upper()
+    if base.lower().endswith(".csv"):
         base = base[:-4]
     for ex, data in ohlcv_map.items():
-        filename = f"{base}_{ex}_data.csv"
+        filename = datasets_dir / f"{base}_{ex}_data.csv"
         save_to_csv(filename, info, data)
         print(f"Data written to {filename}")
 
-    mode = input("Select mode: buyback or liquidation (b/l): ").strip().lower()
+    mode = prompt("Select mode: buyback or liquidation (b/l): ").strip().lower()
     if mode.startswith("b"):
         try:
-            pct_input = input(
+            pct_input = prompt(
                 "Minimum intraday surge percentage (default 75): "
             ).strip()
             surge_pct = float(pct_input) if pct_input else 75.0
@@ -58,7 +91,7 @@ def main() -> None:
         surge_pct = abs(surge_pct)
         avgs = []
         for ex, data in ohlcv_map.items():
-            surge_filename = f"{base}_{ex}_surges.csv"
+            surge_filename = datasets_dir / f"{base}_{ex}_surges.csv"
             avg = save_surge_snippets(
                 surge_filename,
                 data,
@@ -72,16 +105,16 @@ def main() -> None:
         print(f"Average PH percentage: {avg}")
 
         try:
-            final_price = float(input("Final desired price for buyback: "))
-            q_pct = float(input("Increase in sell rate q percentage: "))
-            step_input = input(
+            final_price = float(prompt("Final desired price for buyback: "))
+            q_pct = float(prompt("Increase in sell rate q percentage: "))
+            step_input = prompt(
                 "Price step percentage for schedule (default 5): "
             ).strip()
             step_pct = float(step_input) if step_input else 5.0
         except ValueError:
             print("Invalid numeric input")
             return
-        buyback_filename = f"{base}_buyback.csv"
+        buyback_filename = datasets_dir / f"{base}_buyback.csv"
         save_buyback_model(
             buyback_filename,
             info["price"],
@@ -92,12 +125,12 @@ def main() -> None:
             step_pct,
         )
         print(f"Buyback model written to {buyback_filename}")
-        chart_file = buyback_filename.replace(".csv", ".png")
+        chart_file = datasets_dir / f"{base}_buyback.png"
         plot_buyback_chart(buyback_filename, chart_file)
         print(f"Buyback chart written to {chart_file}")
     elif mode.startswith("l"):
         try:
-            pct_input = input(
+            pct_input = prompt(
                 "Maximum intraday selloff percentage (default -50): "
             ).strip()
             selloff_pct = float(pct_input) if pct_input else -50.0
@@ -107,7 +140,7 @@ def main() -> None:
         selloff_pct = -abs(selloff_pct)
         avgs = []
         for ex, data in ohlcv_map.items():
-            selloff_filename = f"{base}_{ex}_selloffs.csv"
+            selloff_filename = datasets_dir / f"{base}_{ex}_selloffs.csv"
             avg = save_selloff_snippets(
                 selloff_filename,
                 data,
@@ -121,18 +154,18 @@ def main() -> None:
         print(f"Average PH percentage: {avg}")
 
         try:
-            final_price = float(input("Final desired price for liquidation: "))
+            final_price = float(prompt("Final desired price for liquidation: "))
             q_pct = float(
-                input("Increase in sell buy rate q percentage: ")
+                prompt("Increase in sell buy rate q percentage: ")
             )
-            step_input = input(
+            step_input = prompt(
                 "Price step percentage for schedule (default 5): "
             ).strip()
             step_pct = float(step_input) if step_input else 5.0
         except ValueError:
             print("Invalid numeric input")
             return
-        liquidation_filename = f"{base}_liquidation.csv"
+        liquidation_filename = datasets_dir / f"{base}_liquidation.csv"
         save_liquidation_model(
             liquidation_filename,
             info["price"],

--- a/src/model/crypto_data.py
+++ b/src/model/crypto_data.py
@@ -44,6 +44,7 @@ EXCHANGE_ALIASES = {
     "gateio": "gate",
     "bybit_spot": "bybit",
     "bybit-spot": "bybit",
+    "okex": "okx",
 }
 
 

--- a/tests/test_exchange_utils.py
+++ b/tests/test_exchange_utils.py
@@ -10,3 +10,4 @@ def test_exchange_normalization():
     assert _normalize_exchange_id('mxc') == 'mexc'
     assert _normalize_exchange_id('gate') == 'gate'
     assert _normalize_exchange_id('bybit_spot') == 'bybit'
+    assert _normalize_exchange_id('okex') == 'okx'


### PR DESCRIPTION
## Summary
- Drop the animated ASCII art banner and show a concise intro message
- Document the simpler greeting and store all CSV/PNG files under `dist/datasets/`
- Normalize CoinGecko's `okex` identifier to ccxt `okx` so OKX markets load

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba071941208326a3600a3002ba0511