### PR TITLE
Fix Huobi exchange mapping and add Huobi fetch test

### DIFF
--- a/src/model/crypto_data.py
+++ b/src/model/crypto_data.py
@@ -12,7 +12,6 @@ from typing import Dict, List, Tuple
 
 import ccxt
 import requests
-from tqdm import tqdm
 
 try:
     from tqdm import tqdm
@@ -79,7 +78,7 @@ EXCHANGE_ALIASES = {
     "okex": "okx",
     "crypto_com": "cryptocom",
     "hashkey_exchange": "hashkey",
-    "huobi": "htx",
+    "huobi": "huobi",
     "p2pb2b": "p2b",
 }
 
@@ -106,7 +105,7 @@ ALLOWED_QUOTES = {
 
 # Exchanges that consistently fail to provide OHLCV data via ccxt. Treat them as
 # unsupported to avoid noisy warnings during normal operation.
-EXCHANGE_BLACKLIST = {"huobi", "lbank", "phemex", "latoken"}
+EXCHANGE_BLACKLIST = {"lbank", "phemex", "latoken"}
 
 # Quote currencies considered "dollar" variations. Only markets using one of
 # these as the quote currency will be fetched. This avoids cross pairs such as
@@ -126,7 +125,7 @@ ALLOWED_QUOTES = {
 
 # Exchanges that consistently fail to provide OHLCV data via ccxt. Treat them as
 # unsupported to avoid noisy warnings during normal operation.
-EXCHANGE_BLACKLIST = {"huobi", "lbank", "phemex", "latoken"}
+EXCHANGE_BLACKLIST = {"lbank", "phemex", "latoken"}
 
 
 def _normalize_exchange_id(exchange_id: str) -> str:

--- a/tests/test_exchange_utils.py
+++ b/tests/test_exchange_utils.py
@@ -13,7 +13,7 @@ def test_exchange_normalization():
     assert _normalize_exchange_id('okex') == 'okx'
     assert _normalize_exchange_id('crypto_com') == 'cryptocom'
     assert _normalize_exchange_id('hashkey_exchange') == 'hashkey'
-    assert _normalize_exchange_id('huobi') == 'htx'
+    assert _normalize_exchange_id('huobi') == 'huobi'
     assert _normalize_exchange_id('p2pb2b') == 'p2b'
 
 

--- a/tests/test_huobi_fetch.py
+++ b/tests/test_huobi_fetch.py
@@ -1,0 +1,29 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from model import crypto_data
+
+def test_fetch_ohlcv_huobi(monkeypatch):
+    markets = [("huobi", "BTC/USDT")]
+    monkeypatch.setattr(crypto_data, "_coin_markets", lambda ticker: markets)
+
+    class Huobi:
+        symbols = ["BTC/USDT"]
+        def __init__(self, params=None):
+            pass
+        def load_markets(self):
+            return
+        def fetch_ohlcv(self, symbol, timeframe="1d", since=0, limit=1000):
+            assert symbol == "BTC/USDT"
+            assert since > 0
+            return [[since, 1, 2, 3, 4, 5]]
+
+    fake_ccxt = types.SimpleNamespace(exchanges=["huobi"], huobi=Huobi)
+    monkeypatch.setattr(crypto_data, "ccxt", fake_ccxt)
+
+    data, failures = crypto_data.fetch_ohlcv("btc", exchange="huobi")
+    assert failures == []
+    assert data["huobi"][0][1:] == [1, 2, 3, 4, 5]


### PR DESCRIPTION
## Summary
- Map Huobi correctly instead of aliasing to HTX and remove it from the exchange blacklist
- Ensure tqdm is an optional dependency
- Add unit test verifying Huobi OHLCV retrieval

## Testing
- `pytest -q`
- `PYTHONPATH=src python - <<'PY'
from model.crypto_data import fetch_ohlcv
try:
    data, failures = fetch_ohlcv('btc', exchange='huobi')
    print('rows', len(data.get('huobi', [])))
    print('failures', failures)
except Exception as e:
    print('error', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bcae5cb7e88326bbbed881d70d6689