### PR TITLE
Fix Huobi mapping, support Latoken/LBank, show CoinGecko exchanges, alias Coinbase

### DIFF
--- a/src/model/cli.py
+++ b/src/model/cli.py
@@ -83,7 +83,9 @@ def main() -> None:
     init(autoreset=True)
 
     def prompt(text: str) -> str:
-        return input(Fore.YELLOW + text + Style.RESET_ALL)
+        value = input(Fore.YELLOW + text + Style.RESET_ALL + "\n")
+        print()
+        return value
 
     parser = argparse.ArgumentParser(description="Fetch token info and OHLCV data")
     parser.add_argument("ticker", nargs="?", help="Token ticker symbol, e.g. btc")

--- a/tests/test_coin_info.py
+++ b/tests/test_coin_info.py
@@ -39,6 +39,13 @@ def test_fetch_coin_info_prompts_for_supply(monkeypatch):
             }
 
     monkeypatch.setattr(crypto_data.requests, "get", lambda url, timeout=30: Resp())
-    monkeypatch.setattr("builtins.input", lambda prompt="": "12345")
+    captured = {}
+
+    def fake_input(prompt=""):
+        captured["prompt"] = prompt
+        return "12345"
+
+    monkeypatch.setattr("builtins.input", fake_input)
     info = crypto_data.fetch_coin_info("foo")
     assert info["circulating_supply"] == 12345.0
+    assert captured["prompt"].endswith("\n")

--- a/tests/test_exchange_listing.py
+++ b/tests/test_exchange_listing.py
@@ -1,0 +1,38 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from model import crypto_data
+
+
+def test_prints_available_exchanges(monkeypatch, capsys):
+    markets = [
+        (crypto_data._normalize_exchange_id("gdax"), "BTC/USDT"),
+        ("bar", "BTC/USDT"),
+    ]
+    monkeypatch.setattr(crypto_data, "_coin_markets", lambda ticker: markets)
+
+    class DummyExchange:
+        symbols = ["BTC/USDT"]
+        options = {}
+
+        def __init__(self, params=None):
+            pass
+
+        def load_markets(self):
+            return
+
+        def fetch_ohlcv(self, symbol, timeframe="1d", since=0, limit=1000):
+            return [[since or 0, 1, 2, 3, 4, 5]]
+
+    fake_ccxt = types.SimpleNamespace(exchanges=["foo"])
+    setattr(fake_ccxt, "foo", DummyExchange)
+    monkeypatch.setattr(crypto_data, "ccxt", fake_ccxt)
+
+    crypto_data.fetch_ohlcv("btc", exchange="foo")
+    out = capsys.readouterr().out
+    assert "coinbase" in out
+    assert "bar" in out
+    assert "gdax" not in out

--- a/tests/test_exchange_utils.py
+++ b/tests/test_exchange_utils.py
@@ -13,7 +13,8 @@ def test_exchange_normalization():
     assert _normalize_exchange_id('okex') == 'okx'
     assert _normalize_exchange_id('crypto_com') == 'cryptocom'
     assert _normalize_exchange_id('hashkey_exchange') == 'hashkey'
-    assert _normalize_exchange_id('huobi') == 'htx'
+    assert _normalize_exchange_id('gdax') == 'coinbase'
+    assert _normalize_exchange_id('huobi') == 'huobi'
     assert _normalize_exchange_id('p2pb2b') == 'p2b'
 
 

--- a/tests/test_huobi_fetch.py
+++ b/tests/test_huobi_fetch.py
@@ -1,0 +1,33 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from model import crypto_data
+
+def test_fetch_ohlcv_huobi(monkeypatch):
+    markets = [("huobi", "BTC/USDT")]
+    monkeypatch.setattr(crypto_data, "_coin_markets", lambda ticker: markets)
+
+    class Huobi:
+        symbols = ["BTC/USDT"]
+        options = {}
+
+        def __init__(self, params=None):
+            pass
+
+        def load_markets(self):
+            return
+
+        def fetch_ohlcv(self, symbol, timeframe="1d", since=0, limit=1000):
+            assert symbol == "BTC/USDT"
+            assert since > 0
+            return [[since, 1, 2, 3, 4, 5]]
+
+    fake_ccxt = types.SimpleNamespace(exchanges=["huobi"], huobi=Huobi)
+    monkeypatch.setattr(crypto_data, "ccxt", fake_ccxt)
+
+    data, failures = crypto_data.fetch_ohlcv("btc", exchange="huobi")
+    assert failures == []
+    assert data["huobi"][0][1:] == [1, 2, 3, 4, 5]

--- a/tests/test_latoken_lbank_fetch.py
+++ b/tests/test_latoken_lbank_fetch.py
@@ -1,0 +1,42 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from model import crypto_data
+
+def _run_exchange(exchange_id, monkeypatch):
+    markets = [(exchange_id, "BTC/USDT")]
+    monkeypatch.setattr(crypto_data, "_coin_markets", lambda ticker: markets)
+
+    class DummyExchange:
+        symbols = ["BTC/USDT"]
+        options = {}
+
+        def __init__(self, params=None):
+            pass
+
+        def load_markets(self):
+            return
+
+        def fetch_ohlcv(self, symbol, timeframe="1d", since=0, limit=1000):
+            assert symbol == "BTC/USDT"
+            assert since > 0
+            return [[since, 1, 2, 3, 4, 5]]
+
+    fake_ccxt = types.SimpleNamespace(exchanges=[exchange_id])
+    setattr(fake_ccxt, exchange_id, DummyExchange)
+    monkeypatch.setattr(crypto_data, "ccxt", fake_ccxt)
+
+    data, failures = crypto_data.fetch_ohlcv("btc", exchange=exchange_id)
+    assert failures == []
+    assert data[exchange_id][0][1:] == [1, 2, 3, 4, 5]
+
+
+def test_fetch_ohlcv_latoken(monkeypatch):
+    _run_exchange("latoken", monkeypatch)
+
+
+def test_fetch_ohlcv_lbank(monkeypatch):
+    _run_exchange("lbank", monkeypatch)

--- a/tests/test_nonstandard_symbol.py
+++ b/tests/test_nonstandard_symbol.py
@@ -1,0 +1,53 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from model import crypto_data
+
+
+def test_fetch_ohlcv_handles_renamed_base(monkeypatch, capsys):
+    monkeypatch.setattr(crypto_data, "_get_coin_id", lambda ticker: "chrono.tech")
+
+    class Resp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "tickers": [
+                    {
+                        "base": "TIMECHRONO",
+                        "target": "USDT",
+                        "market": {"identifier": "gate-io"},
+                    }
+                ]
+            }
+
+    monkeypatch.setattr(crypto_data.requests, "get", lambda url, timeout=30: Resp())
+
+    class DummyExchange:
+        symbols = ["TIMECHRONO/USDT"]
+        options = {}
+
+        def __init__(self, params=None):
+            pass
+
+        def load_markets(self):
+            return
+
+        def fetch_ohlcv(self, symbol, timeframe="1d", since=0, limit=1000):
+            assert symbol == "TIMECHRONO/USDT"
+            return [[since or 0, 1, 2, 3, 4, 5]]
+
+    fake_ccxt = types.SimpleNamespace(exchanges=["gate"])
+    setattr(fake_ccxt, "gate", DummyExchange)
+    monkeypatch.setattr(crypto_data, "ccxt", fake_ccxt)
+
+    data, failures = crypto_data.fetch_ohlcv("time", exchange="gate")
+    out = capsys.readouterr().out
+    assert "gate" in out
+    assert failures == []
+    assert data["gate"][0][1:] == [1, 2, 3, 4, 5]
+

--- a/tests/test_prompt_clear.py
+++ b/tests/test_prompt_clear.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from model import crypto_data
+
+
+def test_get_coin_id_clears_and_uses_newline(monkeypatch, capsys):
+    class Resp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return [
+                {"id": "coin-a", "symbol": "btc", "name": "Coin A"},
+                {"id": "coin-b", "symbol": "btc", "name": "Coin B"},
+            ]
+
+    monkeypatch.setattr(crypto_data.requests, "get", lambda url, timeout=30: Resp())
+
+    captured = {}
+
+    def fake_input(prompt=""):
+        captured["prompt"] = prompt
+        return "1"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    coin_id = crypto_data._get_coin_id("btc")
+    assert coin_id == "coin-a"
+    assert captured["prompt"].endswith("\n")
+    out = capsys.readouterr().out
+    assert out.endswith("\033[H\033[2J")


### PR DESCRIPTION
## Summary
- Map CoinGecko's legacy `gdax` identifier to ccxt's `coinbase` so Coinbase markets display correctly
- Silence matplotlib font warnings by forcing the Agg backend when generating buyback charts
- Extend exchange normalization and listing tests to cover the Coinbase alias
- Clear the terminal after choosing a coin and put all prompts on their own line for easier reading

## Testing
- `pytest -q`
- `pyinstaller --name crypto-fetch --onefile src/model/cli.py --paths src`
- `PYTHONPATH=src python - <<'PY'
from model.crypto_data import fetch_ohlcv
try:
    data, failures = fetch_ohlcv('btc', exchange='huobi')
    print('huobi rows', len(data.get('huobi', [])))
    print('failures', failures)
except Exception as e:
    print('error', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bcae5cb7e88326bbbed881d70d6689