### PR TITLE
Fix Huobi mapping, support Latoken/LBank, show CoinGecko exchanges, alias Coinbase

### DIFF
--- a/src/model/cli.py
+++ b/src/model/cli.py
@@ -83,7 +83,9 @@ def main() -> None:
     init(autoreset=True)
 
     def prompt(text: str) -> str:
-        return input(Fore.YELLOW + text + Style.RESET_ALL)
+        sys.stdout.write(Fore.YELLOW + text + Style.RESET_ALL)
+        sys.stdout.flush()
+        return input()
 
     parser = argparse.ArgumentParser(description="Fetch token info and OHLCV data")
     parser.add_argument("ticker", nargs="?", help="Token ticker symbol, e.g. btc")

--- a/src/model/crypto_data.py
+++ b/src/model/crypto_data.py
@@ -12,31 +12,6 @@ from typing import Dict, List, Tuple
 
 import ccxt
 import requests
-from tqdm import tqdm
-
-try:
-    from tqdm import tqdm
-except Exception:  # pragma: no cover - fallback when tqdm is missing
-    def tqdm(iterable, **_):
-        return iterable
-
-try:
-    from tqdm import tqdm
-except Exception:  # pragma: no cover - fallback when tqdm is missing
-    def tqdm(iterable, **_):
-        return iterable
-
-try:
-    from tqdm import tqdm
-except Exception:  # pragma: no cover - fallback when tqdm is missing
-    def tqdm(iterable, **_):
-        return iterable
-
-try:
-    from tqdm import tqdm
-except Exception:  # pragma: no cover - fallback when tqdm is missing
-    def tqdm(iterable, **_):
-        return iterable
 
 try:
     from tqdm import tqdm
@@ -79,15 +54,11 @@ EXCHANGE_ALIASES = {
     "okex": "okx",
     "crypto_com": "cryptocom",
     "hashkey_exchange": "hashkey",
-    "huobi": "htx",
+    "gdax": "coinbase",
+    "huobi": "huobi",
     "p2pb2b": "p2b",
 }
 
-# Exchanges that consistently fail to provide OHLCV data via ccxt. Treat them as
-# unsupported to avoid noisy warnings during normal operation. Currently empty
-# so all exchanges are attempted.
-EXCHANGE_BLACKLIST: set[str] = set()
-
 # Quote currencies considered "dollar" variations. Only markets using one of
 # these as the quote currency will be fetched. This avoids cross pairs such as
 # ``LTC/BTC`` or fiat pairs like ``BTC/JPY``.
@@ -103,30 +74,6 @@ ALLOWED_QUOTES = {
     "PAX",
     "GUSD",
 }
-
-# Exchanges that consistently fail to provide OHLCV data via ccxt. Treat them as
-# unsupported to avoid noisy warnings during normal operation.
-EXCHANGE_BLACKLIST = {"huobi", "lbank", "phemex", "latoken"}
-
-# Quote currencies considered "dollar" variations. Only markets using one of
-# these as the quote currency will be fetched. This avoids cross pairs such as
-# ``LTC/BTC`` or fiat pairs like ``BTC/JPY``.
-ALLOWED_QUOTES = {
-    "USD",
-    "USDT",
-    "USDC",
-    "BUSD",
-    "DAI",
-    "TUSD",
-    "USDD",
-    "USDP",
-    "PAX",
-    "GUSD",
-}
-
-# Exchanges that consistently fail to provide OHLCV data via ccxt. Treat them as
-# unsupported to avoid noisy warnings during normal operation.
-EXCHANGE_BLACKLIST = {"huobi", "lbank", "phemex", "latoken"}
 
 
 def _normalize_exchange_id(exchange_id: str) -> str:
@@ -170,10 +117,12 @@ def _get_coin_id(ticker: str) -> str:
         print(f"{idx}. {coin['name']} ({coin['id']})")
 
     while True:
-        choice = input(f"Select coin [1-{len(coins)}]: ")
+        print(f"Select coin [1-{len(coins)}]: ", end="", flush=True)
+        choice = input()
         try:
             idx = int(choice)
             if 1 <= idx <= len(coins):
+                print("\033[H\033[2J", end="")
                 return coins[idx - 1]["id"]
         except ValueError:
             pass
@@ -197,7 +146,8 @@ def fetch_coin_info(ticker: str) -> Dict[str, float]:
     if not supply:
         print("Failed to fetch circulating supply from CoinGecko.")
         while True:
-            user_input = input("Please enter the circulating supply manually: ")
+            print("Please enter the circulating supply manually: ", end="", flush=True)
+            user_input = input()
             try:
                 supply = float(user_input)
                 if supply > 0:
@@ -222,11 +172,10 @@ def _coin_markets(ticker: str) -> List[Tuple[str, str]]:
         ) from exc
     data = resp.json()
     markets: List[Tuple[str, str]] = []
-    base_upper = ticker.upper()
     for entry in data.get("tickers", []):
         base = entry["base"].upper()
         quote = entry["target"].upper()
-        if base != base_upper or quote not in ALLOWED_QUOTES:
+        if quote not in ALLOWED_QUOTES:
             continue
         exchange_id = entry["market"]["identifier"]
         pair = f"{base}/{quote}"
@@ -259,23 +208,23 @@ def fetch_ohlcv(
     markets = _coin_markets(ticker)
     logger.debug("Found %d markets for %s", len(markets), ticker)
 
-    supported_markets = [
-        m for m in markets if m[0] in ccxt.exchanges and m[0] not in EXCHANGE_BLACKLIST
-    ]
+    # Display all exchanges reported by CoinGecko so users can verify which
+    # markets will be attempted.
+    discovered = sorted({ex for ex, _ in markets})
+    if discovered:
+        print("Available exchanges:", ", ".join(discovered))
+    else:
+        print("No exchanges reported on CoinGecko")
+
+    supported_markets = [m for m in markets if m[0] in ccxt.exchanges]
     markets_by_exchange: Dict[str, List[str]] = {}
     for ex, pair in supported_markets:
         markets_by_exchange.setdefault(ex, []).append(pair)
 
     collected: List[str] = warnings if warnings is not None else []
 
-    # Record markets that cannot be fetched via ccxt or are blacklisted.
-    unsupported = sorted(
-        {
-            ex
-            for ex, _ in markets
-            if ex not in ccxt.exchanges or ex in EXCHANGE_BLACKLIST
-        }
-    )
+    # Record markets that cannot be fetched via ccxt.
+    unsupported = sorted({ex for ex, _ in markets if ex not in ccxt.exchanges})
     if unsupported:
         collected.append("Unsupported exchanges: " + ", ".join(unsupported))
 
@@ -320,6 +269,9 @@ def fetch_ohlcv(
 
     def _fetch_from_exchange(ex_name: str, symbol: str) -> List[List[float]]:
         exchange_class = getattr(ccxt, ex_name)({"enableRateLimit": True})
+        if ex_name == "huobi":
+            exchange_class.options["defaultType"] = "spot"
+            exchange_class.options["fetchMarkets"] = {"types": {"spot": True}}
         timeframe = "1d"
         since = since_start
         all_data: List[List[float]] = []
@@ -776,6 +728,12 @@ def plot_buyback_chart(csv_filename: str, image_filename: str) -> None:
                 continue
     if not prices:
         return
+    import logging
+    import matplotlib
+
+    # Suppress verbose font manager warnings and ensure a headless backend.
+    logging.getLogger("matplotlib.font_manager").setLevel(logging.ERROR)
+    matplotlib.use("Agg")
     import matplotlib.pyplot as plt
 
     plt.figure()

--- a/tests/test_coin_info.py
+++ b/tests/test_coin_info.py
@@ -23,7 +23,7 @@ def test_fetch_coin_info_handles_http_error(monkeypatch):
     assert "Too Many Requests" in str(exc.value)
 
 
-def test_fetch_coin_info_prompts_for_supply(monkeypatch):
+def test_fetch_coin_info_prompts_for_supply(monkeypatch, capsys):
     monkeypatch.setattr(crypto_data, "_get_coin_id", lambda ticker: "foo")
 
     class Resp:
@@ -39,6 +39,8 @@ def test_fetch_coin_info_prompts_for_supply(monkeypatch):
             }
 
     monkeypatch.setattr(crypto_data.requests, "get", lambda url, timeout=30: Resp())
-    monkeypatch.setattr("builtins.input", lambda prompt="": "12345")
+    monkeypatch.setattr("builtins.input", lambda: "12345")
     info = crypto_data.fetch_coin_info("foo")
     assert info["circulating_supply"] == 12345.0
+    out = capsys.readouterr().out
+    assert "Please enter the circulating supply manually: \n" not in out

--- a/tests/test_exchange_listing.py
+++ b/tests/test_exchange_listing.py
@@ -1,0 +1,38 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from model import crypto_data
+
+
+def test_prints_available_exchanges(monkeypatch, capsys):
+    markets = [
+        (crypto_data._normalize_exchange_id("gdax"), "BTC/USDT"),
+        ("bar", "BTC/USDT"),
+    ]
+    monkeypatch.setattr(crypto_data, "_coin_markets", lambda ticker: markets)
+
+    class DummyExchange:
+        symbols = ["BTC/USDT"]
+        options = {}
+
+        def __init__(self, params=None):
+            pass
+
+        def load_markets(self):
+            return
+
+        def fetch_ohlcv(self, symbol, timeframe="1d", since=0, limit=1000):
+            return [[since or 0, 1, 2, 3, 4, 5]]
+
+    fake_ccxt = types.SimpleNamespace(exchanges=["foo"])
+    setattr(fake_ccxt, "foo", DummyExchange)
+    monkeypatch.setattr(crypto_data, "ccxt", fake_ccxt)
+
+    crypto_data.fetch_ohlcv("btc", exchange="foo")
+    out = capsys.readouterr().out
+    assert "coinbase" in out
+    assert "bar" in out
+    assert "gdax" not in out

--- a/tests/test_exchange_utils.py
+++ b/tests/test_exchange_utils.py
@@ -13,7 +13,8 @@ def test_exchange_normalization():
     assert _normalize_exchange_id('okex') == 'okx'
     assert _normalize_exchange_id('crypto_com') == 'cryptocom'
     assert _normalize_exchange_id('hashkey_exchange') == 'hashkey'
-    assert _normalize_exchange_id('huobi') == 'htx'
+    assert _normalize_exchange_id('gdax') == 'coinbase'
+    assert _normalize_exchange_id('huobi') == 'huobi'
     assert _normalize_exchange_id('p2pb2b') == 'p2b'
 
 

--- a/tests/test_huobi_fetch.py
+++ b/tests/test_huobi_fetch.py
@@ -1,0 +1,33 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from model import crypto_data
+
+def test_fetch_ohlcv_huobi(monkeypatch):
+    markets = [("huobi", "BTC/USDT")]
+    monkeypatch.setattr(crypto_data, "_coin_markets", lambda ticker: markets)
+
+    class Huobi:
+        symbols = ["BTC/USDT"]
+        options = {}
+
+        def __init__(self, params=None):
+            pass
+
+        def load_markets(self):
+            return
+
+        def fetch_ohlcv(self, symbol, timeframe="1d", since=0, limit=1000):
+            assert symbol == "BTC/USDT"
+            assert since > 0
+            return [[since, 1, 2, 3, 4, 5]]
+
+    fake_ccxt = types.SimpleNamespace(exchanges=["huobi"], huobi=Huobi)
+    monkeypatch.setattr(crypto_data, "ccxt", fake_ccxt)
+
+    data, failures = crypto_data.fetch_ohlcv("btc", exchange="huobi")
+    assert failures == []
+    assert data["huobi"][0][1:] == [1, 2, 3, 4, 5]

--- a/tests/test_latoken_lbank_fetch.py
+++ b/tests/test_latoken_lbank_fetch.py
@@ -1,0 +1,42 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from model import crypto_data
+
+def _run_exchange(exchange_id, monkeypatch):
+    markets = [(exchange_id, "BTC/USDT")]
+    monkeypatch.setattr(crypto_data, "_coin_markets", lambda ticker: markets)
+
+    class DummyExchange:
+        symbols = ["BTC/USDT"]
+        options = {}
+
+        def __init__(self, params=None):
+            pass
+
+        def load_markets(self):
+            return
+
+        def fetch_ohlcv(self, symbol, timeframe="1d", since=0, limit=1000):
+            assert symbol == "BTC/USDT"
+            assert since > 0
+            return [[since, 1, 2, 3, 4, 5]]
+
+    fake_ccxt = types.SimpleNamespace(exchanges=[exchange_id])
+    setattr(fake_ccxt, exchange_id, DummyExchange)
+    monkeypatch.setattr(crypto_data, "ccxt", fake_ccxt)
+
+    data, failures = crypto_data.fetch_ohlcv("btc", exchange=exchange_id)
+    assert failures == []
+    assert data[exchange_id][0][1:] == [1, 2, 3, 4, 5]
+
+
+def test_fetch_ohlcv_latoken(monkeypatch):
+    _run_exchange("latoken", monkeypatch)
+
+
+def test_fetch_ohlcv_lbank(monkeypatch):
+    _run_exchange("lbank", monkeypatch)

--- a/tests/test_nonstandard_symbol.py
+++ b/tests/test_nonstandard_symbol.py
@@ -1,0 +1,53 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from model import crypto_data
+
+
+def test_fetch_ohlcv_handles_renamed_base(monkeypatch, capsys):
+    monkeypatch.setattr(crypto_data, "_get_coin_id", lambda ticker: "chrono.tech")
+
+    class Resp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "tickers": [
+                    {
+                        "base": "TIMECHRONO",
+                        "target": "USDT",
+                        "market": {"identifier": "gate-io"},
+                    }
+                ]
+            }
+
+    monkeypatch.setattr(crypto_data.requests, "get", lambda url, timeout=30: Resp())
+
+    class DummyExchange:
+        symbols = ["TIMECHRONO/USDT"]
+        options = {}
+
+        def __init__(self, params=None):
+            pass
+
+        def load_markets(self):
+            return
+
+        def fetch_ohlcv(self, symbol, timeframe="1d", since=0, limit=1000):
+            assert symbol == "TIMECHRONO/USDT"
+            return [[since or 0, 1, 2, 3, 4, 5]]
+
+    fake_ccxt = types.SimpleNamespace(exchanges=["gate"])
+    setattr(fake_ccxt, "gate", DummyExchange)
+    monkeypatch.setattr(crypto_data, "ccxt", fake_ccxt)
+
+    data, failures = crypto_data.fetch_ohlcv("time", exchange="gate")
+    out = capsys.readouterr().out
+    assert "gate" in out
+    assert failures == []
+    assert data["gate"][0][1:] == [1, 2, 3, 4, 5]
+

--- a/tests/test_prompt_clear.py
+++ b/tests/test_prompt_clear.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from model import crypto_data
+
+
+def test_get_coin_id_clears_without_newline(monkeypatch, capsys):
+    class Resp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return [
+                {"id": "coin-a", "symbol": "btc", "name": "Coin A"},
+                {"id": "coin-b", "symbol": "btc", "name": "Coin B"},
+            ]
+
+    monkeypatch.setattr(crypto_data.requests, "get", lambda url, timeout=30: Resp())
+    monkeypatch.setattr("builtins.input", lambda: "1")
+
+    coin_id = crypto_data._get_coin_id("btc")
+    assert coin_id == "coin-a"
+    out = capsys.readouterr().out
+    assert "Select coin [1-2]: \n" not in out
+    assert out.endswith("\033[H\033[2J")


### PR DESCRIPTION
## Summary
- Map CoinGecko's legacy `gdax` identifier to ccxt's `coinbase` so Coinbase markets display correctly
- Silence matplotlib font warnings by forcing the Agg backend when generating buyback charts
- List all CoinGecko markets, support Latoken/LBank, and correct Huobi's mapping to ensure spot data retrieval
- Clear the console after coin selection and keep interactive prompts inline without extra newlines

## Testing
- `pytest -q`
- `pyinstaller --name crypto-fetch --onefile src/model/cli.py --paths src`
- `PYTHONPATH=src python - <<'PY'
from model.crypto_data import fetch_ohlcv
try:
    data, failures = fetch_ohlcv('btc', exchange='huobi')
    print('huobi rows', len(data.get('huobi', [])))
    print('failures', failures)
except Exception as e:
    print('error', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bcae5cb7e88326bbbed881d70d6689