### PR TITLE
Remove colorama fallbacks and enforce color styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ Paper Hands Model [Version 1.0]
 © Bitmaker L.L.C-FZ. All rights reserved.
 ```
 
-If `colorama` is available, prompts are highlighted to provide a friendlier
-interface, but the CLI also runs without it for standalone builds.
+Prompts are always colorised using
+[`colorama`](https://github.com/tartley/colorama), which ships as a project
+dependency and is bundled into standalone builds.
 
 Example:
 
@@ -103,7 +104,8 @@ bundle it with [PyInstaller](https://pyinstaller.org/):
 
 ```bash
 pip install pyinstaller
-pyinstaller --name crypto-fetch --onefile src/model/cli.py --paths src
+pyinstaller --name crypto-fetch --onefile src/model/cli.py --paths src \
+  --hidden-import colorama
 ```
 
 The compiled binary will be available in the `dist/` directory.

--- a/src/model/cli.py
+++ b/src/model/cli.py
@@ -10,17 +10,7 @@ import time
 from pathlib import Path
 from typing import List
 
-try:
-    from colorama import Fore, Style, init
-except ModuleNotFoundError:  # pragma: no cover - fallback when colorama isn't bundled
-    class _NoColor:
-        def __getattr__(self, name: str) -> str:
-            return ""
-
-    Fore = Style = _NoColor()
-
-    def init(*_args, **_kwargs):  # type: ignore
-        pass
+from colorama import Fore, Style, init
 
 from model.crypto_data import (
     fetch_coin_info,

--- a/src/model/crypto_data.py
+++ b/src/model/crypto_data.py
@@ -12,14 +12,7 @@ from typing import Dict, List, Tuple
 
 import ccxt
 import requests
-try:
-    from colorama import Fore, Style
-except ModuleNotFoundError:  # pragma: no cover
-    class _NoColor:
-        def __getattr__(self, name: str) -> str:
-            return ""
-
-    Fore = Style = _NoColor()
+from colorama import Fore, Style
 
 try:
     from tqdm import tqdm

--- a/tests/test_coin_info.py
+++ b/tests/test_coin_info.py
@@ -45,5 +45,6 @@ def test_fetch_coin_info_prompts_for_supply(monkeypatch, capsys):
     assert info["circulating_supply"] == 12345.0
     out = capsys.readouterr().out
     ansi = re.compile(r"\x1b\[[0-9;]*m")
+    assert ansi.search(out)
     clean = ansi.sub("", out)
     assert "Please enter the circulating supply manually: \n" not in clean

--- a/tests/test_prompt_clear.py
+++ b/tests/test_prompt_clear.py
@@ -27,6 +27,7 @@ def test_get_coin_id_clears_without_newline(monkeypatch, capsys):
     assert coin_id == "coin-a"
     out = capsys.readouterr().out
     ansi = re.compile(r"\x1b\[[0-9;]*m")
+    assert ansi.search(out)
     clean = ansi.sub("", out)
     assert "Select coin [1-2]: \n" not in clean
     assert clean.endswith("\033[H\033[2J")


### PR DESCRIPTION
## Summary
- Import colorama directly in cli and data modules
- Initialise colorama in CLI entrypoint only
- Document required colorama dependency and bundle it with PyInstaller

## Testing
- `pytest -q`
- `pyinstaller --name crypto-fetch --onefile src/model/cli.py --paths src --hidden-import colorama`
- `script -q -c "printf 'nosuchcoin\n' | ./dist/crypto-fetch" /tmp/term.log` *(fails to reach CoinGecko; ANSI codes present)*


------
https://chatgpt.com/codex/tasks/task_e_68bd6ee2554883269c7af818707636b0